### PR TITLE
Prevent the DI to optimize the default bus

### DIFF
--- a/src/App/Bundle/DependencyInjection/WakeonwebServiceBusExtension.php
+++ b/src/App/Bundle/DependencyInjection/WakeonwebServiceBusExtension.php
@@ -31,7 +31,10 @@ class WakeonwebServiceBusExtension extends Extension
             $commandBusConfig = $config['command_buses'];
 
             if (array_key_exists('default', $commandBusConfig)) {
-                $container->setAlias('wakeonweb.service_bus.command_bus_default', sprintf('prooph_service_bus.%s', $commandBusConfig['default']));
+                $container
+                    ->setAlias('wakeonweb.service_bus.command_bus_default', sprintf('prooph_service_bus.%s', $commandBusConfig['default']))
+                    ->setPublic(true)
+                ;
             }
 
             $container->getDefinition('wakeonweb.service_bus.command_bus_guesser')->replaceArgument(0, $commandBusConfig['route_message_to_bus']);


### PR DESCRIPTION
When using the guesser instead of the bus, those ones are removed from the container by the compiler (because private by default). Switching the visibility of the alias as public prevent this behavior and makes me happy.